### PR TITLE
[DEV-86] Add shell CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.16.0-stretch
+    steps:
+      - checkout
+      - run: echo "simple build executed"


### PR DESCRIPTION
This PR just adds a simple no-op build file to connect this project to CircleCI. In a follow-up story I will add semantic release to this so it will publish to NPM when merged to master. In order to set up the Circle ENV variables for semantic release, I need this repo set up as a project in Circle to begin with.

No testing or deploy necessary.



