### PR TITLE
Whitespace change to trigger version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clc_inc/eslint-config-clc",
   "version": "2.0.0",
+
   "description": "Shareable eslint configuration",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Forgot to use the correct semantic versioning type in last commit message.